### PR TITLE
Add Meson support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: d
-
 sudo: false
+dist: trusty
+
+addons:
+  apt:
+    packages:
+      - pkg-config
+      - zlib1g-dev
+      - libevent-dev
+      - libssl-dev
 
 d:
   # order: latest DMD, oldest DMD, LDC/GDC, remaining DMD versions
@@ -9,16 +17,31 @@ d:
   # catching most DMD version related build failures early
   - dmd-2.073.1
   - dmd-2.068.2
-  - ldc-1.1.0
-  - ldc-1.0.0
-  - ldc-0.17.0
+  - ldc-1.3.0
+  - ldc-1.2.0
+  - ldc-1.1.1
   - dmd-2.072.2
   - dmd-2.071.2
   - dmd-2.070.2
   - dmd-2.069.2
+
+before_install:
+  - pip3 install meson>=0.40
+
+install:
+  - mkdir .ntmp
+  - curl -L https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip -o .ntmp/ninja-linux.zip
+  - unzip .ntmp/ninja-linux.zip -d .ntmp
+
+before_script:
+  - export PATH=$PATH:$PWD/.ntmp
 
 script:
   - dub build -b release
   - dub test
   - dub build --root examples/htmlgenerator
   - dub build --root examples/htmlserver
+  - mkdir build && cd build
+  - meson ..
+  - ninja -j4
+  - DESTDIR=/tmp/diet_inst_target ninja install

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,59 @@
+project('Diet-NG', 'd',
+    meson_version: '>=0.40',
+    license: 'MIT',
+    version: '1.4.0'
+)
+
+project_soversion = '0'
+project_version   = meson.project_version()
+
+pkgc = import('pkgconfig')
+
+#
+# Sources
+#
+diet_src = [
+    'source/diet/defs.d',
+    'source/diet/dom.d',
+    'source/diet/html.d',
+    'source/diet/input.d',
+    'source/diet/internal/html.d',
+    'source/diet/internal/string.d',
+    'source/diet/parser.d',
+    'source/diet/traits.d',
+]
+
+src_dir = include_directories('source/')
+
+#
+# Targets
+#
+diet_lib = library('diet',
+        [diet_src],
+        include_directories: [src_dir],
+        install: true,
+        version: project_version,
+        soversion: project_soversion
+)
+pkgc.generate(name: 'diet',
+              libraries: [diet_lib],
+              subdirs: 'd/diet',
+              version: project_version,
+              description: 'Next generation Diet template compiler.'
+)
+
+#
+# Tests
+#
+diet_test_exe = executable('test_diet',
+    [diet_src],
+    include_directories: [src_dir],
+    d_args: meson.get_compiler('d').unittest_args(),
+    link_args: '-main'
+)
+test('test_diet', diet_test_exe)
+
+#
+# Install
+#
+install_subdir('source/diet/', install_dir: 'include/d/diet/')


### PR DESCRIPTION
Hi!
Same as always, but this time the file is very, very simple.
Adding Meson build files to the examples will likely also make sense in future.
Support for Travis is included, so builds will be tested.

Thanks!
    Matthias
