### PR TITLE
separate meson build steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ script:
   - dub test
   - dub build --root examples/htmlgenerator
   - dub build --root examples/htmlserver
+  # test building with Meson
   - mkdir build && cd build
   - meson ..
   - ninja -j4


### PR DESCRIPTION
So we can easily skip them on http://ci.dlang.io.