### PR TITLE
meson: Small tweak to use Diet as a subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,11 +35,18 @@ diet_lib = library('diet',
         version: project_version,
         soversion: project_soversion
 )
+
 pkgc.generate(name: 'diet',
               libraries: [diet_lib],
               subdirs: 'd/diet',
               version: project_version,
               description: 'Next generation Diet template compiler.'
+)
+
+# for use by Vibe.d and others which embed this as subproject
+diet_dep = declare_dependency(
+    link_with: [diet_lib],
+    include_directories: [src_dir]
 )
 
 #


### PR DESCRIPTION
This makes using Diet as a Meson suproject a lot easier, because it allows using a shortcut in other Meson projects (just pulling in the `diet_dep` internal dependency, instead of redefining it in every project)