### PR TITLE
Fix visibility attribute

### DIFF
--- a/source/diet/traits.d
+++ b/source/diet/traits.d
@@ -275,7 +275,7 @@ unittest {
 	r.compileHTMLDietString!(":foo bar", CTX);
 }
 
-package struct DietTraitsAttribute {}
+struct DietTraitsAttribute {}
 
 private bool hasFilterCT(TRAITS...)(string filter)
 {


### PR DESCRIPTION
This is currently  blocking [1]. It looks like the struct is declared as package, but I don't see a package defined anywhere so the access modifier will default to private, thus making this line [2] an error. Probably creating a package hierarchy would be a more elegant fix, but I am not sufficiently familiar with codebase to do that and simply grepping for `package` reveals that this is the single occurrence of it.

Please push a new tag for diet-ng after this is merged, so that the CI uses the latest verrsion.

Thanks!

[1] https://github.com/dlang/dmd/pull/9393
[2] https://github.com/rejectedsoftware/diet-ng/blob/master/source/diet/input.d#L7