### PR TITLE
Fix extends keyword

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -330,7 +330,7 @@ In the case of error `Missing include input file` check [templates placement](#t
 Blocks and Extensions
 ---------------------
 
-`extend file(.ext)`
+`extends file(.ext)`
 
 **TODO!**
 


### PR DESCRIPTION
extend doesn't seem to exist

https://github.com/rejectedsoftware/diet-ng/blob/97a11cc676bbc14ac06bb1c23d28242e2bc6cf72/source/diet/parser.d#L699