### PR TITLE
Allow included templates to be extended through blocks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: d
 sudo: false
-dist: trusty
+dist: xenial
 
 branches:
   only:
@@ -11,30 +11,20 @@ addons:
     packages:
       - pkg-config
       - zlib1g-dev
-      - libevent-dev
       - libssl-dev
 
 d:
-  # order: latest DMD, oldest DMD, LDC/GDC, remaining DMD versions
-  # this way the overall test time gets cut down (GDC/LDC are a lot
-  # slower tham DMD, so they should be started early), while still
-  # catching most DMD version related build failures early
-  - dmd-2.079.0
-  - dmd-2.072.2
-  - ldc-1.8.0
-  - ldc-1.7.0
-  - ldc-1.6.0
-  - ldc-1.5.0
-  - ldc-1.4.0
-  - ldc-1.3.0
-  - ldc-1.2.0
-  - dmd-2.078.3
-  - dmd-2.077.1
-  - dmd-2.076.1
-  - dmd-2.075.1
-  - dmd-2.074.1
-  - dmd-2.073.2
-  - dmd-2.072.2
+  - dmd-2.087.1
+  - dmd-2.086.1
+  - dmd-2.085.1
+  - dmd-2.084.1
+  - dmd-2.083.1
+  - dmd-2.082.1
+  - ldc-1.16.0
+  - ldc-1.15.0
+  - ldc-1.14.0
+  - ldc-1.13.0
+  - ldc-1.12.0
 
 #before_install:
   #- pyenv global system 3.6

--- a/examples/htmlserver/dub.sdl
+++ b/examples/htmlserver/dub.sdl
@@ -1,4 +1,3 @@
 name "htmlserver"
 dependency "diet-ng" path="../.."
-dependency "vibe-d" version="~>0.8.3-alpha.1"
-versions "VibeDefaultMain"
+dependency "vibe-d" version="~>0.8.5"

--- a/examples/htmlserver/source/app.d
+++ b/examples/htmlserver/source/app.d
@@ -1,4 +1,5 @@
 import diet.html;
+import vibe.core.core;
 import vibe.http.server;
 import vibe.stream.wrapper;
 
@@ -9,10 +10,12 @@ void render(scope HTTPServerRequest req, scope HTTPServerResponse res)
 	dst.compileHTMLDietFile!("index.dt", iterations);
 }
 
-shared static this()
+void main()
 {
 	auto settings = new HTTPServerSettings;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
 	settings.port = 8080;
 	listenHTTP(settings, &render);
+
+	runApplication();
 }

--- a/source/diet/dom.d
+++ b/source/diet/dom.d
@@ -35,6 +35,13 @@ string expectExpression(const(Attribute) att)
 	return att.contents[0].value;
 }
 
+Node[] clone(in Node[] nodes)
+{
+	auto ret = new Node[](nodes.length);
+	foreach (i, ref n; ret) n = nodes[i].clone;
+	return ret;
+}
+
 bool isExpression(const(Attribute) att) { return att.contents.length == 1 && att.contents[0].kind == AttributeContent.Kind.interpolation; }
 bool isText(const(Attribute) att) { return att.contents.length == 0 || att.contents.length == 1 && att.contents[0].kind == AttributeContent.Kind.text; }
 
@@ -134,6 +141,16 @@ NodeContent[] toNodeContent(in AttributeContent[] contents, Location loc)
 	@property inout(Attribute) id() inout { return getAttribute("id"); }
 	/// Returns "class" attribute - a white space separated list of style class identifiers.
 	@property inout(Attribute) class_() inout { return getAttribute("class"); }
+
+	Node clone()
+	const {
+		auto ret = new Node(this.loc, this.name, null, null, this.attribs, this.translationKey);
+		ret.attributes.length = this.attributes.length;
+		foreach (i, ref a; ret.attributes) a = this.attributes[i].dup;
+		ret.contents.length = this.contents.length;
+		foreach (i, ref c; ret.contents) c = this.contents[i].clone;
+		return ret;
+	}
 
 	/** Adds a piece of text to the node's contents.
 
@@ -375,6 +392,16 @@ struct NodeContent {
 	static NodeContent interpolation(string text, Location loc) { return NodeContent(Kind.interpolation, loc, Node.init, text); }
 	/// Creates a new raw string interpolation node content value.
 	static NodeContent rawInterpolation(string text, Location loc) { return NodeContent(Kind.rawInterpolation, loc, Node.init, text); }
+
+	@property NodeContent clone()
+	const {
+		NodeContent ret;
+		ret.kind = this.kind;
+		ret.loc = this.loc;
+		ret.value = this.value;
+		if (this.node) ret.node = this.node.clone;
+		return ret;
+	}
 
 	/// Compares node content for equality.
 	bool opEquals(in ref NodeContent other)

--- a/source/diet/parser.d
+++ b/source/diet/parser.d
@@ -511,8 +511,8 @@ unittest { // includes
 	testFail("include main", "Dependency cycle detected for this module.");
 	testFail("include inc2", "Missing include input file: inc2");
 	testFail("include #{p}", "Dynamic includes are not supported.");
-	testFail("include inc\n\tp", "Includes cannot have children.");
-	testFail("p\ninclude inc\n\tp", "Includes cannot have children.");
+	testFail("include inc\n\tp", "Only 'block' allowed as children of includes.");
+	testFail("p\ninclude inc\n\tp", "Only 'block' allowed as children of includes.");
 }
 
 unittest { // extensions
@@ -589,6 +589,36 @@ unittest { // extensions
 		new Node(Location("main.dt", 2), "p", null, null)
 	]);
 }
+
+unittest { // include extensions
+	Node[] parse(string diet) {
+		auto files = [
+			InputFile("main.dt", diet),
+			InputFile("root.dt", "p\n\tblock a"),
+		];
+		return parseDiet(files).nodes;
+	}
+
+	assert(parse("body\n\tinclude root\n\t\tblock a\n\t\t\tem") == [
+		new Node(Location("main.dt", 0), "body", null, [
+			NodeContent.tag(new Node(Location("root.dt", 0), "p", null, [
+				NodeContent.tag(new Node(Location("main.dt", 3), "em", null, null))
+			]))
+		])
+	]);
+
+	assert(parse("body\n\tinclude root\n\t\tblock a\n\t\t\tem\n\tinclude root\n\t\tblock a\n\t\t\tstrong") == [
+		new Node(Location("main.dt", 0), "body", null, [
+			NodeContent.tag(new Node(Location("root.dt", 0), "p", null, [
+				NodeContent.tag(new Node(Location("main.dt", 3), "em", null, null))
+			])),
+			NodeContent.tag(new Node(Location("root.dt", 0), "p", null, [
+				NodeContent.tag(new Node(Location("main.dt", 6), "strong", null, null))
+			]))
+		])
+	]);
+}
+
 
 unittest { // test CTFE-ability
 	static const result = parseDiet("foo#id.cls(att=\"val\", att2=1+3, att3='test#{4}it')\n\tbar");
@@ -693,7 +723,7 @@ private Node[] parseDietWithExtensions(FileInfo[] files, size_t file_index, ref 
 	auto floc = Location(files[file_index].name, 0);
 	enforcep(!import_stack.canFind(file_index), "Dependency cycle detected for this module.", floc);
 
-	auto nodes = files[file_index].nodes;
+	Node[] nodes = files[file_index].nodes;
 	if (!nodes.length) return null;
 
 	if (nodes[0].name == "extends") {
@@ -724,8 +754,14 @@ private Node[] parseDietWithExtensions(FileInfo[] files, size_t file_index, ref 
 			blocks ~= BlockInfo(name, mode, contents);
 		}
 
+		// save the original file contents for a possible later parsing as part of an
+		// extension include directive (blocks are replaced in-place as part of the parsing
+		// process)
+		auto new_files = files.dup;
+		new_files[base_idx].nodes = clone(new_files[base_idx].nodes);
+
 		// parse base template
-		return parseDietWithExtensions(files, base_idx, blocks, import_stack ~ file_index);
+		return parseDietWithExtensions(new_files, base_idx, blocks, import_stack ~ file_index);
 	}
 
 	static string extractFilename(Node n)
@@ -777,12 +813,31 @@ private Node[] parseDietWithExtensions(FileInfo[] files, size_t file_index, ref 
 			if (ret.isNull) ret = [];
 		} else if (n.name == "include") {
 			auto name = extractFilename(n);
-			enforcep(n.contents.length == 1, "Includes cannot have children.", n.loc);
 			auto fidx = files.countUntil!(f => matchesName(f.name, name, files[file_index].name));
 			enforcep(fidx >= 0, "Missing include input file: "~name, n.loc);
-			insert(parseDietWithExtensions(files, fidx, blocks, import_stack ~ file_index));
+
+			if (n.contents.length > 1) {
+				auto dummy = new Node(n.loc, "extends");
+				dummy.addText(name, n.contents[0].loc);
+
+				Node[] children = [dummy];
+
+				foreach (nc; n.contents[1 .. $]) {
+					enforcep(nc.node !is null && nc.node.name == "block",
+						"Only 'block' allowed as children of includes.", nc.loc);
+					children ~= nc.node;
+				}
+
+				import std.path : extension;
+				auto dummyfil = FileInfo("include"~extension(files[file_index].name), children);
+
+				BlockInfo[] sub_blocks;
+				insert(parseDietWithExtensions(files ~ dummyfil, files.length, sub_blocks, import_stack));
+			} else {
+				insert(parseDietWithExtensions(files, fidx, blocks, import_stack ~ file_index));
+			}
 		} else {
-			n.contents.modifyArray!((nc) {
+			n.contents = n.contents.mapJoin!((nc) {
 				Nullable!(NodeContent[]) rn;
 				if (nc.kind == NodeContent.Kind.node) {
 					auto mod = processNode(nc.node);
@@ -798,7 +853,7 @@ private Node[] parseDietWithExtensions(FileInfo[] files, size_t file_index, ref 
 		return ret;
 	}
 
-	nodes.modifyArray!(processNode);
+	nodes = nodes.mapJoin!(processNode);
 
 	assert(nodes.all!(n => n.name != "block"));
 
@@ -1542,15 +1597,21 @@ private bool matchesName(string filename, string logical_name, string parent_nam
 	return false;
 }
 
-private void modifyArray(alias modify, T)(ref T[] arr)
+private T[] mapJoin(alias modify, T)(T[] arr)
 {
-	size_t i = 0;
-	while (i < arr.length) {
+	T[] ret;
+	size_t start = 0;
+	foreach (i; 0 .. arr.length) {
 		auto mod = modify(arr[i]);
-		if (mod.isNull()) i++;
-		else {
-			arr = arr[0 .. i] ~ mod.get() ~ arr[i+1 .. $];
-			i += mod.length;
+		if (!mod.isNull()) {
+			ret ~= arr[start .. i] ~ mod.get();
+			start = i + 1;
 		}
 	}
+
+	if (start == 0) return arr;
+
+	ret ~= arr[start .. $];
+
+	return ret;
 }

--- a/source/diet/parser.d
+++ b/source/diet/parser.d
@@ -1203,7 +1203,7 @@ private bool parseTag(ref string input, ref size_t idx, ref Node dst, ref bool h
 	If there a a newline at the end, it will be appended to the contents of the
 	destination node.
 */
-private void parseTextLine(alias TR)(ref string input, ref Node dst, ref Location loc, bool translate = true)
+private void parseTextLine(alias TR, bool translate = true)(ref string input, ref Node dst, ref Location loc)
 {
 	import std.algorithm.comparison : among;
 
@@ -1215,7 +1215,7 @@ private void parseTextLine(alias TR)(ref string input, ref Node dst, ref Locatio
 		input = input[idx .. $];
 		dst.translationKey ~= kln;
 		auto tln = TR(kln);
-		parseTextLine!TR(tln, dst, loccopy, false);
+		parseTextLine!(TR, false)(tln, dst, loccopy);
 		return;
 	}
 


### PR DESCRIPTION
This allows to perform extension in reverse dependency order; instead of extending a parent template, the included template serves as the extension base and can be used multiple times within the same document. 

A possible application for this are pre-layouted content blocks with one or more text areas defined by blocks. The final page can then be assembled of any number of these content blocks, defining the inner contents using the usual Diet syntax. This was previously only possible through embedded functions with parameters or scoped variables referenced within the included template, both resulting in the need to fall back to D syntax for the contents.