### PR TITLE
Avoid recompiling/parsing files that are identical with identical traits

### DIFF
--- a/source/diet/html.d
+++ b/source/diet/html.d
@@ -11,6 +11,12 @@ import diet.parser;
 import diet.traits;
 
 
+private template _dietFileData(string filename)
+{
+	import diet.internal.string : stripUTF8BOM;
+	private static immutable contents = stripUTF8BOM(import(filename));
+}
+
 /** Compiles a Diet template file that is available as a string import.
 
 	The final HTML will be written to the given `_diet_output` output range.
@@ -31,30 +37,13 @@ import diet.traits;
 */
 template compileHTMLDietFile(string filename, ALIASES...)
 {
-	import diet.internal.string : stripUTF8BOM;
-	private static immutable contents = stripUTF8BOM(import(filename));
-	alias compileHTMLDietFile = compileHTMLDietFileString!(filename, contents, ALIASES);
+	alias compileHTMLDietFile = compileHTMLDietFileString!(filename, _dietFileData!filename.contents, ALIASES);
 }
 
 
-/** Compiles a Diet template given as a string, with support for includes and extensions.
-
-	This function behaves the same as `compileHTMLDietFile`, except that the
-	contents of the file are
-
-	The final HTML will be written to the given `_diet_output` output range.
-
-	Params:
-		filename = The name to associate with `contents`
-		contents = The contents of the Diet template
-		ALIASES = A list of variables to make available inside of the template,
-			as well as traits structs annotated with the `@dietTraits`
-			attribute.
-		dst = The output range to write the generated HTML to.
-
-	See_Also: `compileHTMLDietFile`, `compileHTMLDietString`, `compileHTMLDietStrings`
-*/
-template compileHTMLDietFileString(string filename, alias contents, ALIASES...)
+// provide a place to cache compilation of a file. No reason to rebuild every
+// time a file is used.
+private template realCompileHTMLDietFileString(string filename, alias contents, TRAITS...)
 {
 	import std.conv : to;
 	private static immutable _diet_files = collectFiles!(filename, contents);
@@ -94,7 +83,6 @@ template compileHTMLDietFileString(string filename, alias contents, ALIASES...)
 		pragma(msg, "Using cached Diet HTML template "~filename~"...");
 		enum _dietParser = import(_diet_cache_file_name);
 	} else {
-		alias TRAITS = DietTraits!ALIASES;
 		pragma(msg, "Compiling Diet HTML template "~filename~"...");
 		private Document _diet_nodes() { return applyTraits!TRAITS(parseDiet!(translate!TRAITS)(_diet_files)); }
 		enum _dietParser = getHTMLMixin(_diet_nodes(), dietOutputRangeName, getHTMLOutputStyle!TRAITS);
@@ -108,6 +96,29 @@ template compileHTMLDietFileString(string filename, alias contents, ALIASES...)
 			}
 		}
 	}
+}
+/** Compiles a Diet template given as a string, with support for includes and extensions.
+
+	This function behaves the same as `compileHTMLDietFile`, except that the
+	contents of the file are
+
+	The final HTML will be written to the given `_diet_output` output range.
+
+	Params:
+		filename = The name to associate with `contents`
+		contents = The contents of the Diet template
+		ALIASES = A list of variables to make available inside of the template,
+			as well as traits structs annotated with the `@dietTraits`
+			attribute.
+		dst = The output range to write the generated HTML to.
+
+	See_Also: `compileHTMLDietFile`, `compileHTMLDietString`, `compileHTMLDietStrings`
+*/
+template compileHTMLDietFileString(string filename, alias contents, ALIASES...)
+{
+	alias TRAITS = DietTraits!ALIASES;
+
+	alias _dietParser = realCompileHTMLDietFileString!(filename, contents, TRAITS)._dietParser;
 
 	// uses the correct range name and removes 'dst' from the scope
 	private void exec(R)(ref R _diet_output)


### PR DESCRIPTION
I have some diet templates I reuse with different aliases. For instance, the same page may be accessed from a different route with different configuration/permissions. In this case, I use the same template, but maybe with different model data passed in.

I noticed that when doing this, I see 2 "compiling template ..." messages for that template. There is no difference in the way it is compiled, as long as the TRAITS are the same. So to avoid redoing that work in CTFE, this consolidates those into one template, and then does the mixin with the aliases separately.

Not a huge savings on most projects, but useful where templates are reused.