### PR TITLE
Add back in import for std.conv.to

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('Diet-NG', 'd',
     meson_version: '>=0.40',
     license: 'MIT',
-    version: '1.7.1'
+    version: '1.7.2'
 )
 
 project_soversion = '0'

--- a/source/diet/html.d
+++ b/source/diet/html.d
@@ -186,6 +186,10 @@ private template realCompileHTMLDietFileString(string filename, alias contents, 
 */
 template compileHTMLDietFileString(string filename, alias contents, ALIASES...)
 {
+	// This import should be REMOVED for 2.0.0, as it was unintentionally
+	// exposed for use inside the mixin. See issue #81
+	import std.conv : to;
+
 	alias TRAITS = DietTraits!ALIASES;
 
 	alias _dietParser = realCompileHTMLDietFileString!(filename, contents, TRAITS)._dietParser;


### PR DESCRIPTION
An import for `std.conv.to` leaked to any mixed in diet code. So naturally, diet templates were written (in vibe.d skeleton no less) that used `to` but forgot to import it.

This adds back in an import. But we should consider for 2.0.0 removing all leaked imports from the mixin (probably by moving the mixin into a separate isolated module).

Update meson build version assuming this is going to be released as 1.7.2