### PR TITLE
Add support for DMD 2.094 -preview=in switch

### DIFF
--- a/source/diet/defs.d
+++ b/source/diet/defs.d
@@ -27,7 +27,7 @@ alias DietParserException = Exception;
 		Throws a `DietParserException` when called with a `false` condition at
 		run time.
 */
-void enforcep(bool cond, lazy string text, in ref Location loc) @safe
+void enforcep(bool cond, lazy string text, in Location loc) @safe
 {
 	if (__ctfe) {
 		import std.conv : to;

--- a/source/diet/dom.d
+++ b/source/diet/dom.d
@@ -163,7 +163,7 @@ NodeContent[] toNodeContent(in AttributeContent[] contents, Location loc)
 			text = The text to append to the node
 			loc = Location in the source file
 	*/
-	void addText(string text, in ref Location loc)
+	void addText(string text, in Location loc)
 	{
 		if (contents.length && contents[$-1].kind == NodeContent.Kind.text && contents[$-1].loc == loc)
 			contents[$-1].value ~= text;
@@ -405,7 +405,7 @@ struct NodeContent {
 	}
 
 	/// Compares node content for equality.
-	bool opEquals(in ref NodeContent other)
+	bool opEquals(const scope ref NodeContent other)
 	const {
 		if (this.kind != other.kind) return false;
 		if (this.loc != other.loc) return false;

--- a/source/diet/html.d
+++ b/source/diet/html.d
@@ -717,7 +717,7 @@ private string getDoctypeMixin(ref CTX ctx, in Node node) @safe
 	return ctx.rawText(node.loc, "<"~doctype_str~">");
 }
 
-private string getCodeMixin(ref CTX ctx, in ref Node node, bool in_pre) @safe
+private string getCodeMixin(ref CTX ctx, const ref Node node, bool in_pre) @safe
 {
 	enforcep(node.attributes.length == 0, "Code lines may not have attributes.", node.loc);
 	enforcep(node.attribs == NodeAttribs.none, "Code lines may not specify translation or text block suffixes.", node.loc);
@@ -741,7 +741,7 @@ private string getCodeMixin(ref CTX ctx, in ref Node node, bool in_pre) @safe
 	return ret;
 }
 
-private string getCommentMixin(ref CTX ctx, in ref Node node) @safe
+private string getCommentMixin(ref CTX ctx, const ref Node node) @safe
 {
 	string ret = ctx.rawText(node.loc, "<!--");
 	ctx.depth++;

--- a/source/diet/internal/string.d
+++ b/source/diet/internal/string.d
@@ -38,7 +38,7 @@ string dstringEscape(char ch)
 	}
 }
 
-string dstringEscape(in ref string str)
+string dstringEscape(in string str)
 {
 	string ret;
 	foreach( ch; str ) ret ~= dstringEscape(ch);

--- a/source/diet/parser.d
+++ b/source/diet/parser.d
@@ -672,8 +672,8 @@ Document parseDiet(alias TR = identity)(const(InputFile)[] files)
 string identity(string str) nothrow @safe @nogc { return str; }
 
 
-private string parseIdent(in ref string str, ref size_t start,
-	   	string breakChars, in ref Location loc)
+private string parseIdent(in string str, ref size_t start,
+	   	string breakChars, in Location loc)
 @safe {
 	import std.array : back;
 	/* The stack is used to keep track of opening and
@@ -1340,7 +1340,7 @@ private string skipLine(ref string input, ref Location loc)
 	return ret;
 }
 
-private void parseAttributes(ref string input, ref size_t i, ref Node node, in ref Location loc)
+private void parseAttributes(ref string input, ref size_t i, ref Node node, in Location loc)
 @safe {
 	assert(i < input.length && input[i] == '(');
 	i++;
@@ -1384,7 +1384,7 @@ private void parseAttributes(ref string input, ref size_t i, ref Node node, in r
 	i++;
 }
 
-private void parseAttributeText(string input, ref AttributeContent[] dst, in ref Location loc)
+private void parseAttributeText(string input, ref AttributeContent[] dst, in Location loc)
 @safe {
 	size_t sidx = 0, idx = 0;
 
@@ -1421,7 +1421,7 @@ private void parseAttributeText(string input, ref AttributeContent[] dst, in ref
 	input = input[idx .. $];
 }
 
-private string skipUntilClosingBrace(in ref string s, ref size_t idx, in ref Location loc)
+private string skipUntilClosingBrace(in string s, ref size_t idx, in Location loc)
 @safe {
 	import std.algorithm.comparison : among;
 
@@ -1438,7 +1438,7 @@ private string skipUntilClosingBrace(in ref string s, ref size_t idx, in ref Loc
 	assert(false);
 }
 
-private string skipUntilClosingBracket(in ref string s, ref size_t idx, in ref Location loc)
+private string skipUntilClosingBracket(in string s, ref size_t idx, in Location loc)
 @safe {
 	import std.algorithm.comparison : among;
 
@@ -1455,7 +1455,8 @@ private string skipUntilClosingBracket(in ref string s, ref size_t idx, in ref L
 	assert(false);
 }
 
-private string skipIdent(in ref string s, ref size_t idx, string additional_chars, in ref Location loc, bool accept_empty = false, bool require_alpha_start = false)
+private string skipIdent(in string s, ref size_t idx, string additional_chars,
+	in Location loc, bool accept_empty = false, bool require_alpha_start = false)
 @safe {
 	import std.ascii : isAlpha;
 
@@ -1494,7 +1495,7 @@ private string skipIndent(ref string input)
 
 private bool isIndentChar(dchar ch) @safe { return ch == ' ' || ch == '\t'; }
 
-private string skipAnyWhitespace(in ref string s, ref size_t idx)
+private string skipAnyWhitespace(in string s, ref size_t idx)
 @safe {
 	import std.ascii : isWhite;
 
@@ -1562,7 +1563,7 @@ private bool isStringLiteral(string str)
 	assert(!isStringLiteral(`"name" value="#{name}"`));
 }
 
-private string skipExpression(in ref string s, ref size_t idx, in ref Location loc, bool multiline = false)
+private string skipExpression(in string s, ref size_t idx, in Location loc, bool multiline = false)
 @safe {
 	string clamp_stack;
 	size_t start = idx;
@@ -1599,7 +1600,8 @@ private string skipExpression(in ref string s, ref size_t idx, in ref Location l
 	return ctstrip(s[start .. idx]);
 }
 
-private string skipAttribString(in ref string s, ref size_t idx, char delimiter, in ref Location loc)
+
+private string skipAttribString(in string s, ref size_t idx, char delimiter, in Location loc)
 @safe {
 	size_t start = idx;
 	while( idx < s.length ){


### PR DESCRIPTION
```
This will allow users to use -preview=in as soon as it's released.
'in ref' on string doesn't make much sense, so it was turned into a simple 'in'.
'Location' is a string + an 'int', and while that would be passed by ref with the
new switch, there's not much point in ensuring ref here, as the difference is
minimal, but prevents using rvalues, so it was also turned into a simple 'in'.
Lastly, for node, it was changed to be simply 'const ref', so as to keep the 'ref'.
```

@s-ludwig : Would be nice to have this in a release, as Vibe.d requires it (https://github.com/dlang/dmd/pull/11632)