### PR TITLE
Trivial: Update example's Vibe.d dep to v0.9.0

### DIFF
--- a/examples/htmlserver/dub.sdl
+++ b/examples/htmlserver/dub.sdl
@@ -1,6 +1,6 @@
 name "htmlserver"
 dependency "diet-ng" path="../.."
-dependency "vibe-d" version="~>0.8.5"
+dependency "vibe-d" version="~>0.9.0"
 configuration "application" {
     targetType "executable"
 }


### PR DESCRIPTION
Not a big deal, but will allow Buildkite to pass.